### PR TITLE
Replace log with logrus

### DIFF
--- a/rubrik/provider.go
+++ b/rubrik/provider.go
@@ -1,7 +1,7 @@
 package rubrikcdm
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/rubrik/resource_rubrik_assign_sla_test.go
+++ b/rubrik/resource_rubrik_assign_sla_test.go
@@ -2,7 +2,7 @@ package rubrikcdm
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"testing"
 

--- a/rubrik/resource_rubrik_configure_timezone.go
+++ b/rubrik/resource_rubrik_configure_timezone.go
@@ -1,7 +1,7 @@
 package rubrikcdm
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/rubrik/resource_rubrik_configure_timezone_test.go
+++ b/rubrik/resource_rubrik_configure_timezone_test.go
@@ -2,7 +2,7 @@ package rubrikcdm
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/golang/protobuf/proto/clone.go
+++ b/vendor/github.com/golang/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/equal.go
+++ b/vendor/github.com/golang/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/lib.go
+++ b/vendor/github.com/golang/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/golang/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -37,7 +37,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/text.go
+++ b/vendor/github.com/golang/protobuf/proto/text.go
@@ -40,7 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"runtime"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
@@ -2,7 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/hcl2/ext/dynblock"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"unicode/utf8"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
@@ -75,7 +75,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"keys":             funcs.KeysFunc,
 			"length":           funcs.LengthFunc,
 			"list":             funcs.ListFunc,
-			"log":              funcs.LogFunc,
+			log "github.com/sourcegraph-ce/logrus":              funcs.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
 			"map":              funcs.MapFunc,

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"mime"
 	"net/http"
 	"net/url"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
@@ -3,7 +3,7 @@ package disco
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	plugin "github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -4,7 +4,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -9,7 +9,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -15,7 +15,7 @@ package afero
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -4,7 +4,7 @@
 
 package bidi
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // This implementation is a port based on the reference implementation found at:
 // https://www.unicode.org/Public/PROGRAMS/BidiReferenceJava/

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )


### PR DESCRIPTION
Namespace(repository='github.com/sourcegraph-ce/terraform-provider-rubrik', batch_change_name='log-provider-go-with-python-script', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script)